### PR TITLE
Revisions to make Flamingo compile nicely on Ubuntu16.04

### DIFF
--- a/src/flamingo-4.1/src/common/src/compressionargs.h
+++ b/src/flamingo-4.1/src/common/src/compressionargs.h
@@ -15,6 +15,8 @@
 
 #include <set>
 
+#include <cstddef>
+
 #include "typedef.h"
 
 class CompressionArgs {

--- a/src/flamingo-4.1/src/listmerger/src/divideskipmerger.h
+++ b/src/flamingo-4.1/src/listmerger/src/divideskipmerger.h
@@ -147,7 +147,7 @@ mergeWithoutDupls(vector<InvList*> &invLists,
     for(unsigned j = start; j < stop; j++) {	
       unsigned llindex = j - start;
       typename InvList::iterator start, end;
-      expProbe(longListsPointers[llindex], invLists[j]->end(), start, end, candis[i].id);
+      this->expProbe(longListsPointers[llindex], invLists[j]->end(), start, end, candis[i].id);
       typename InvList::iterator iter = lower_bound(start, end, candis[i].id);
       longListsPointers[llindex] = start;
       if(iter != invLists[j]->end() && *iter == candis[i].id) {
@@ -254,7 +254,7 @@ mergeWithDupls(vector<InvList*> &invLists,
   
   vector<InvList*> newInvLists;  
   vector<unsigned> newWeights;  
-  detectDuplicateLists(invLists, newInvLists, newWeights);
+  this->detectDuplicateLists(invLists, newInvLists, newWeights);
   
   // assume that newArray should be sorted according to the length increasing
   unsigned longestSize = newInvLists.at(newInvLists.size()-1)->size();  
@@ -310,7 +310,7 @@ mergeWithDupls(vector<InvList*> &invLists,
     for(unsigned j = start; j < stop; j++) {	
       unsigned llindex = j - start;
       typename InvList::iterator start, end;
-      expProbe(longListsPointers[llindex], newInvLists[j]->end(), start, end, candis[i].id);
+      this->expProbe(longListsPointers[llindex], newInvLists[j]->end(), start, end, candis[i].id);
       
       typename InvList::iterator iter = lower_bound(start, end, candis[i].id);
       longListsPointers[llindex] = iter;
@@ -465,7 +465,7 @@ getQueryStats(vector<InvList*> &invLists,
     for(unsigned j = start; j < stop; j++) {	
       unsigned llindex = j - start;
       typename InvList::iterator start, end;
-      expProbe(longListsPointers[llindex], invLists[j]->end(), start, end, candis[i].id);
+      this->expProbe(longListsPointers[llindex], invLists[j]->end(), start, end, candis[i].id);
       typename InvList::iterator iter = lower_bound(start, end, candis[i].id);      
       longListsPointers[llindex] = start;
       if(iter != invLists[j]->end() && *iter == candis[i].id) {

--- a/src/flamingo-4.1/src/listmerger/src/mergeoptmerger.h
+++ b/src/flamingo-4.1/src/listmerger/src/mergeoptmerger.h
@@ -120,7 +120,7 @@ mergeWithoutDupls(vector<InvList*> &invLists,
         
     for(unsigned i = 0; i < candis.size(); i++) {
       typename InvList::iterator start, end;
-      expProbe(listIter, invLists[j]->end(), start, end, candis[i].id);      
+      this->expProbe(listIter, invLists[j]->end(), start, end, candis[i].id);      
       listIter = lower_bound(start, end, candis[i].id);
       if(listIter != invLists[j]->end() && *listIter == candis[i].id) {
 	candis[i].count++;
@@ -151,7 +151,7 @@ mergeWithDupls(vector<InvList*> &invLists,
   
   vector<InvList*> newInvLists;
   vector<unsigned> newWeights;
-  detectDuplicateLists(invLists, newInvLists, newWeights);
+  this->detectDuplicateLists(invLists, newInvLists, newWeights);
   
   // assume that newArray should be sorted according to the length increasing
   unsigned numShortLists = 0;
@@ -219,7 +219,7 @@ mergeWithDupls(vector<InvList*> &invLists,
     for(unsigned j = start; j < stop; j++) {	
       unsigned llindex = j - start;
       typename InvList::iterator start, end;
-      expProbe(longListsPointers[llindex], newInvLists[j]->end(), start, end, candis[i].id);
+      this->expProbe(longListsPointers[llindex], newInvLists[j]->end(), start, end, candis[i].id);
       
       typename InvList::iterator iter = lower_bound(start, end, candis[i].id);
       longListsPointers[llindex] = iter;


### PR DESCRIPTION
Long time listener, first time caller.

I recently left David Gresham's lab. Today I've been packaging BarNone into a singularity container to make sure it's still runnable in a few years. In doing so, I found a few little changes that were necessary for Flamingo to compile nicely, at least within a Ubuntu 16.04 container from docker hub. I've made those changes here. They appear to be changes with how the language is specified (?!?), but I don't do C++, so I can't really say. It appears to compile fine, but fails a test about comparing the `total_cached` number (which doesn't appear to be defined in the function). However, using it in a singularity container, it gives me the same exact counts tables on some real data as was reported by the version compiled by NYU HPC staff a few years back.

Should these changes get folded into your main repo for ease of others compiling? Do they make sense from a C++ perspective?

If you're curious, the BarNone container is now here:
https://github.com/darachm/barnone-singularity
and here:
https://www.singularity-hub.org/collections/1276

Best of luck.